### PR TITLE
Allow skipping of authentication for NNTP servers

### DIFF
--- a/README-usenet-setup.md
+++ b/README-usenet-setup.md
@@ -34,7 +34,7 @@ bobbi.8bit@gmail.com
 The lines are as follows, in order:
 
  1) IP address of the NNTP server, optionally followed by a colon and then the TCP port number.  If the colon and port number are omitted, port 119 is the default.
- 2) Username to use when connecting to NNTP.
+ 2) Username to use when connecting to NNTP. If your NNTP server does not need authentication then use '-' for the username and password.
  3) Password to use when connecting to NNTP.
  4) ProDOS path of the directory where the email executables are installed.
  5) ProDOS path to the root of the email folder tree.  Mailboxes will be created and managed under this root path.

--- a/apps/nntp65.c
+++ b/apps/nntp65.c
@@ -327,7 +327,7 @@ void readconfigfile(void) {
 
   colon = strchr(cfg_server, ':');
   if (!colon)
-    nntp_port = 110;
+    nntp_port = 119;
   else {
     nntp_port = atoi(colon + 1);    
     *colon = '\0';
@@ -649,19 +649,22 @@ void main(int argc, char *argv[]) {
   if (expect(buf, "20")) // "200" if posting is allowed / "201" if no posting
     error_exit();
 
-  sprintf(sendbuf, "AUTHINFO USER %s\r\n", cfg_user);
-  if (!w5100_tcp_send_recv(sendbuf, buf, NETBUFSZ, DO_SEND, CMD_MODE)) {
-    error_exit();
-  }
-  if (expect(buf, "381")) // Username accepted
-    error_exit();
+  // Skip authentication?
+  if (strcmp(cfg_user, "-") != 0) {
+    sprintf(sendbuf, "AUTHINFO USER %s\r\n", cfg_user);
+    if (!w5100_tcp_send_recv(sendbuf, buf, NETBUFSZ, DO_SEND, CMD_MODE)) {
+      error_exit();
+    }
+    if (expect(buf, "381")) // Username accepted
+      error_exit();
 
-  sprintf(sendbuf, "AUTHINFO PASS %s\r\n", cfg_pass);
-  if (!w5100_tcp_send_recv(sendbuf, buf, NETBUFSZ, DO_SEND, CMD_MODE)) {
-    error_exit();
+    sprintf(sendbuf, "AUTHINFO PASS %s\r\n", cfg_pass);
+    if (!w5100_tcp_send_recv(sendbuf, buf, NETBUFSZ, DO_SEND, CMD_MODE)) {
+      error_exit();
+    }
+    if (expect(buf, "281")) // Authentication successful
+      error_exit();
   }
-  if (expect(buf, "281")) // Authentication successful
-    error_exit();
 
   while (1) {
     msg = fscanf(newsgroupsfp, "%s %s %ld", newsgroup, mailbox, &msgnum);


### PR DESCRIPTION
Hello,

I run a local NNTP server using [leafnode](https://www.leafnode.org/) which does not do authentication. I have added the option to skip NNTP client authentication by specifying a username of '-'.

I chose the dash ('-') character to make it simple and can be changed if needed.