### PR TITLE
Allow skipping of authentication for NNTP server

### DIFF
--- a/README-usenet-setup.md
+++ b/README-usenet-setup.md
@@ -27,7 +27,7 @@ Here is an example config file (with passwords replaced with `****` for obvious 
 Bobbi
 ****
 /H1/IP65
-/DATA/EMAIL
+/H1/DOCUMENTS/EMAIL
 bobbi.8bit@gmail.com
 ```
 

--- a/README-usenet-setup.md
+++ b/README-usenet-setup.md
@@ -34,7 +34,7 @@ bobbi.8bit@gmail.com
 The lines are as follows, in order:
 
  1) IP address of the NNTP server, optionally followed by a colon and then the TCP port number.  If the colon and port number are omitted, port 119 is the default.
- 2) Username to use when connecting to NNTP.
+ 2) Username to use when connecting to NNTP. If your NNTP server does not need authentication then use '-' for the username and password.
  3) Password to use when connecting to NNTP.
  4) ProDOS path of the directory where the email executables are installed.
  5) ProDOS path to the root of the email folder tree.  Mailboxes will be created and managed under this root path.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Recommended optional hardware:
 
 Emai//er has been extensively tested using ProDOS 2.4.2. However, it should not be a problem to run it under other versions of ProDOS.
 
+## Uthernet-II Slot
+
+The default slot is 5. If you have your card in another slot then create a file called `ethernet.slot` using `EDIT.SYSTEM` with your slot number on the first line.
+
 ## Transport Level Security (TLS)
 
 One problem faced by any retrocomputing project of this type is that Transport Layer Security (TLS) is endemic on today's Internet.  While this is great for security, the encryption algorithms are not feasible to implement on a 6502-based system.  In order to bridge the plain text world of the Apple II to today's encrypted Internet, I have set up a Raspberry Pi using several common open source packages as a gateway.

--- a/apps/email.cfg
+++ b/apps/email.cfg
@@ -4,7 +4,7 @@ passwordgoeshere
 NODELETE
 192.168.10.2:25
 apple2.local
-/IP65
-/DATA/EMAIL
+/H1/IP65
+/H1/DOCUMENTS/EMAIL
 bobbi.8bit@gmail.com
 

--- a/apps/news.cfg
+++ b/apps/news.cfg
@@ -1,7 +1,7 @@
 144.76.35.198:119
 usergoeshere
 passwordgoeshere
-/IP65
-/DATA/EMAIL
+/H1/IP65
+/H1/DOCUMENTS/EMAIL
 bobbi.8bit@gmail.com
 

--- a/apps/nntp65.c
+++ b/apps/nntp65.c
@@ -327,7 +327,7 @@ void readconfigfile(void) {
 
   colon = strchr(cfg_server, ':');
   if (!colon)
-    nntp_port = 110;
+    nntp_port = 119;
   else {
     nntp_port = atoi(colon + 1);    
     *colon = '\0';
@@ -649,19 +649,22 @@ void main(int argc, char *argv[]) {
   if (expect(buf, "20")) // "200" if posting is allowed / "201" if no posting
     error_exit();
 
-  sprintf(sendbuf, "AUTHINFO USER %s\r\n", cfg_user);
-  if (!w5100_tcp_send_recv(sendbuf, buf, NETBUFSZ, DO_SEND, CMD_MODE)) {
-    error_exit();
-  }
-  if (expect(buf, "381")) // Username accepted
-    error_exit();
+  // Skip authentication?
+  if (strcmp(cfg_user, "-") != 0) {
+    sprintf(sendbuf, "AUTHINFO USER %s\r\n", cfg_user);
+    if (!w5100_tcp_send_recv(sendbuf, buf, NETBUFSZ, DO_SEND, CMD_MODE)) {
+      error_exit();
+    }
+    if (expect(buf, "381")) // Username accepted
+      error_exit();
 
-  sprintf(sendbuf, "AUTHINFO PASS %s\r\n", cfg_pass);
-  if (!w5100_tcp_send_recv(sendbuf, buf, NETBUFSZ, DO_SEND, CMD_MODE)) {
-    error_exit();
+    sprintf(sendbuf, "AUTHINFO PASS %s\r\n", cfg_pass);
+    if (!w5100_tcp_send_recv(sendbuf, buf, NETBUFSZ, DO_SEND, CMD_MODE)) {
+      error_exit();
+    }
+    if (expect(buf, "281")) // Authentication successful
+      error_exit();
   }
-  if (expect(buf, "281")) // Authentication successful
-    error_exit();
 
   while (1) {
     msg = fscanf(newsgroupsfp, "%s %s %ld", newsgroup, mailbox, &msgnum);

--- a/apps/nntp65.up.c
+++ b/apps/nntp65.up.c
@@ -369,7 +369,7 @@ void readconfigfile(void) {
 
   colon = strchr(cfg_server, ':');
   if (!colon)
-    nntp_port = 110;
+    nntp_port = 119;
   else
     nntp_port = atoi(colon + 1);
 }
@@ -645,19 +645,22 @@ sendmessage:
       if (expect(buf, "200 ")) // "200" if posting is allowed
         error_exit();
 
-      sprintf(sendbuf, "AUTHINFO USER %s\r\n", cfg_user);
-      if (!w5100_tcp_send_recv(sendbuf, buf, NETBUFSZ, DO_SEND, CMD_MODE)) {
-        error_exit();
-      }
-      if (expect(buf, "381")) // Username accepted
-        error_exit();
+      // Skip authentication?
+      if (strcmp(cfg_user, "-") != 0) {
+        sprintf(sendbuf, "AUTHINFO USER %s\r\n", cfg_user);
+        if (!w5100_tcp_send_recv(sendbuf, buf, NETBUFSZ, DO_SEND, CMD_MODE)) {
+          error_exit();
+        }
+        if (expect(buf, "381")) // Username accepted
+          error_exit();
 
-      sprintf(sendbuf, "AUTHINFO PASS %s\r\n", cfg_pass);
-      if (!w5100_tcp_send_recv(sendbuf, buf, NETBUFSZ, DO_SEND, CMD_MODE)) {
-        error_exit();
+        sprintf(sendbuf, "AUTHINFO PASS %s\r\n", cfg_pass);
+        if (!w5100_tcp_send_recv(sendbuf, buf, NETBUFSZ, DO_SEND, CMD_MODE)) {
+          error_exit();
+        }
+        if (expect(buf, "281")) // Authentication successful
+          error_exit();
       }
-      if (expect(buf, "281")) // Authentication successful
-        error_exit();
 
       connected = 1;
     }


### PR DESCRIPTION
Updated pull request to include both **nntp65.c** and **nntp65.up.c** authentication changes.

I run a local NNTP server using [leafnode](https://www.leafnode.org/) which does not do authentication. I have added the option to skip NNTP client authentication by specifying a username of '-'. I chose the dash ('-') character to make it simple and can be changed if needed.

I have succesfully tested both downloading comp.sys.apple2 as well as posting.